### PR TITLE
Fix currency representation and formatting

### DIFF
--- a/src/main/java/com/ite/itea/domain/CheckoutCalculator.java
+++ b/src/main/java/com/ite/itea/domain/CheckoutCalculator.java
@@ -6,6 +6,11 @@ import com.ite.itea.domain.dto.PicturesDto;
 import com.ite.itea.domain.dto.ReceiptDto;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
+import java.text.MessageFormat;
+import java.text.NumberFormat;
+import java.util.Locale;
+
 @Service
 public class CheckoutCalculator {
 
@@ -16,7 +21,7 @@ public class CheckoutCalculator {
         return new ReceiptDto(price, text);
     }
 
-    private String getText(OrderDto orderDto, double price) {
+    private String getText(OrderDto orderDto, long priceInCents) {
         var text = "itea \n";
 
         var amountOfPictures = 0;
@@ -28,23 +33,29 @@ public class CheckoutCalculator {
         }
 
         if (amountOfPictures > 0) {
-            text += "Picture " + 14.99 + " * " + amountOfPictures + "\n";
+            text += MessageFormat.format("Picture 14,99\u00A0€ * {0}\n", amountOfPictures);
         }
 
-        text += "Total " + price;
+        text += "Total " + formatPrice(priceInCents);
 
         return text;
     }
 
-    private double getPrice(OrderDto orderDto) {
-        var price = 0.0;
+    private String formatPrice(long priceInCents) {
+        var currencyFormat = NumberFormat.getCurrencyInstance(Locale.GERMANY);
+        var decimalPrice = BigDecimal.valueOf(priceInCents).movePointLeft(2);
+        return currencyFormat.format(decimalPrice);
+    }
+
+    private long getPrice(OrderDto orderDto) {
+        var priceInCents = 0L;
 
         for (ItemDto itemDto : orderDto.itemDtos()) {
             if (itemDto instanceof PicturesDto) {
-                price += 14.99 * itemDto.getAmount();
+                priceInCents += 1499L * itemDto.getAmount();
             }
         }
 
-        return price;
+        return priceInCents;
     }
 }

--- a/src/main/java/com/ite/itea/domain/dto/ReceiptDto.java
+++ b/src/main/java/com/ite/itea/domain/dto/ReceiptDto.java
@@ -1,5 +1,5 @@
 package com.ite.itea.domain.dto;
 
-public record ReceiptDto(double price, String text) {
+public record ReceiptDto(long priceInCents, String text) {
 
 }

--- a/src/main/java/com/ite/itea/domain/response/ReceiptResponse.java
+++ b/src/main/java/com/ite/itea/domain/response/ReceiptResponse.java
@@ -1,5 +1,5 @@
 package com.ite.itea.domain.response;
 
-public record ReceiptResponse(double price, String text) {
+public record ReceiptResponse(long priceInCents, String text) {
 
 }

--- a/src/main/java/com/ite/itea/presentation/CheckoutController.java
+++ b/src/main/java/com/ite/itea/presentation/CheckoutController.java
@@ -43,7 +43,7 @@ public class CheckoutController {
 
         ReceiptDto receiptDto = checkoutCalculator.calculatePrice(new OrderDto(itemDtoList));
 
-        return new ReceiptResponse(receiptDto.price(), receiptDto.text());
+        return new ReceiptResponse(receiptDto.priceInCents(), receiptDto.text());
     }
 
 }

--- a/src/test/java/com/ite/itea/domain/CheckoutCalculatorTest.java
+++ b/src/test/java/com/ite/itea/domain/CheckoutCalculatorTest.java
@@ -20,8 +20,8 @@ class CheckoutCalculatorTest {
 
         var receipt = checkoutCalculator.calculatePrice(orderDto);
 
-        then(receipt.price()).isEqualTo(29.98);
-        then(receipt.text()).isEqualTo("itea \nPicture 14.99 * 2\nTotal 29.98");
+        then(receipt.priceInCents()).isEqualTo(2998L);
+        then(receipt.text()).isEqualTo("itea \nPicture 14,99\u00A0€ * 2\nTotal 29,98\u00A0€");
     }
 
     @Test
@@ -32,8 +32,8 @@ class CheckoutCalculatorTest {
 
         var receipt = checkoutCalculator.calculatePrice(orderDto);
 
-        then(receipt.price()).isEqualTo(0.0);
-        then(receipt.text()).isEqualTo("itea \nTotal 0.0");
+        then(receipt.priceInCents()).isEqualTo(0L);
+        then(receipt.text()).isEqualTo("itea \nTotal 0,00\u00A0€");
     }
 
 }

--- a/src/test/java/com/ite/itea/presentation/CheckoutControllerTest.java
+++ b/src/test/java/com/ite/itea/presentation/CheckoutControllerTest.java
@@ -39,8 +39,8 @@ class CheckoutControllerTest {
         var entity = this.testRestTemplate.postForEntity("http://localhost:" + this.port + "/checkout", orderRequest, ReceiptResponse.class);
 
         then(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        then(entity.getBody().price()).isEqualTo(29.98);
-        then(entity.getBody().text()).isEqualTo("itea \nPicture 14.99 * 2\nTotal 29.98");
+        then(entity.getBody().priceInCents()).isEqualTo(2998L);
+        then(entity.getBody().text()).isEqualTo("itea \nPicture 14,99\u00A0€ * 2\nTotal 29,98\u00A0€");
     }
 
     @Test


### PR DESCRIPTION
*Should probably also be cherry picked to the other branches.*

To prevent problems with floating point accuracy, we represent prices in cents internally, until they are formatted at the domain boundary, for which we use BigDecimal.
We format prices in the official format with currency symbol.

1. Currency data type:

An alternative solution would be to use BigDecimal everywhere, but in this case we opt against it for the following reasons:
- BigDecimals in itself are not a currency type, but an accurate fixed point decimal type.
- BigDecimals are mutable and not constrained to a specific decimal point position, so an illegal currency value like `14.999` could be accidentally created and passed around through the system before it is realized, causing potentially difficult-to-debug errors (besides the standard mutability issues).
- If no fractional cents are required there is no need for the ability to move the decimal point further than 2 positions, i.e. creating more than 1 fixed point representation.

In general, I would recommend a domain type for money (e.g. a `Money` value object), which uses either long or BigDecimal internally, but without leaking that implementation detail to the outside, allowing to easily replace long with BigDecimal when needed without affecting the users of the type. In this case, the simple solution of using prices in cents, to fix the floating point accurracy problem, seems good enough, since the focus of the kata is on duplication/DRY. However, a domain type for money should probably be considered in other design focused katas (e.g. Information Hiding, YAGNI, etc.).

Further reading on currency representation:
https://stackoverflow.com/questions/3730019/why-not-use-double-or-float-to-represent-currency https://stackoverflow.com/a/45406786/3726133
https://stackoverflow.com/a/45222775/3726133

2. Currency Formatting:

Euro amounts are formatted in a specific, standardized way, which is the same in most countries, e.g., "14,99 €".

Something that is often overlooked by programmers is that most unit symbols are separated from the value by a non-breaking space, which prevents the case of, e.g., "14,99
€" being split into 2 lines, and instead moves the whole formatted value to the next line if it does not fit. Standard libraries typically do that by default (including, Java's `NumberFormat` for currency values. So we only add it manually in cases where we format manually and in tests. The non-breaking space has the hex value `00A0` in unicode, which is written in a Java string literal as `"\u00A0"`.

Further reading on currency formatting:
https://en.wikipedia.org/wiki/Language_and_the_euro https://stackoverflow.com/questions/12560629/java-converting-long-into-currency https://en.wikipedia.org/wiki/Non-breaking_space